### PR TITLE
dismiss of math error by clicking another number

### DIFF
--- a/src/views/Calculator/Calculator.tsx
+++ b/src/views/Calculator/Calculator.tsx
@@ -106,6 +106,7 @@ export default function Calculator() {
       } else if (!willBeNegative) {
         result = result.concat(value);
         setNewNumber(false);
+        setError(false);
       }
       setWillBeNegative(false);
 
@@ -165,7 +166,7 @@ export default function Calculator() {
         ? editing === "y" && displayY
           ? formatted(y)
           : formatted(x)
-        : "Error",
+        : "Math Error",
     [displayY, editing, x, y, error]
   );
 


### PR DESCRIPTION
The math error can now be dismissed by clicking another number